### PR TITLE
Add support for custom timezones per app

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This means:
 - Between 5pm and 7pm, 1 dyno will be running
 - Between 7pm and 9am, no dynos will be running (and maintenance mode will be enabled)
 
-Times are based on the time of the server (Heroku's use UTC).
+By default, times are based on the time of the server (Heroku's use UTC). To override the timezone for all apps, set `$SCALING_SCHEDULE_TIMEZONE` on `heroku-scheduled-scaling`. To override the timezone per app, set `$SCALING_SCHEDULE_TIMEZONE` on the app itself. Valid values are any IANA timezone (eg `Europe/London`).
 
 To review which apps have a scaling config set, try [`heroku-audit`](https://github.com/torchbox/heroku-audit).
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This means:
 - Between 5pm and 7pm, 1 dyno will be running
 - Between 7pm and 9am, no dynos will be running (and maintenance mode will be enabled)
 
-By default, times are based on the time of the server (Heroku's use UTC). To override the timezone for all apps, set `$SCALING_SCHEDULE_TIMEZONE` on `heroku-scheduled-scaling`. To override the timezone per app, set `$SCALING_SCHEDULE_TIMEZONE` on the app itself. Valid values are any IANA timezone (eg `Europe/London`).
+By default, times are in UTC. To override the timezone for all apps, set `$SCALING_SCHEDULE_TIMEZONE` on `heroku-scheduled-scaling`. To override the timezone per app, set `$SCALING_SCHEDULE_TIMEZONE` on the app itself. Valid values are any IANA timezone (eg `Europe/London`).
 
 To review which apps have a scaling config set, try [`heroku-audit`](https://github.com/torchbox/heroku-audit).
 

--- a/heroku_scheduled_scaling/utils.py
+++ b/heroku_scheduled_scaling/utils.py
@@ -1,7 +1,9 @@
 import os
+from datetime import datetime
 from typing import Iterable
 
 import heroku3
+import zoneinfo
 from heroku3.models.app import App
 
 
@@ -25,3 +27,21 @@ def get_heroku_apps() -> list[App]:
         if heroku_teams is None
         else list(get_apps_for_teams(heroku, heroku_teams))
     )
+
+
+def get_zone_info(key: str) -> zoneinfo.ZoneInfo | None:
+    """
+    Attempt to retrive the `ZoneInfo` for a given timezone, or `None`
+    if the input is invalid / zone doesn't exisxt
+    """
+    try:
+        return zoneinfo.ZoneInfo(key)
+    except (zoneinfo.ZoneInfoNotFoundError, ValueError):
+        return None
+
+
+def is_naive(dt: datetime) -> bool:
+    """
+    Determine whether the provided datetime is naive (doesn't contain a timezone).
+    """
+    return dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+import pytest
+from zoneinfo import ZoneInfo
+
+from heroku_scheduled_scaling import utils
+
+
+def test_get_zone_info() -> None:
+    assert (
+        utils.get_zone_info("Europe/London").key  # type:ignore[union-attr]
+        == "Europe/London"
+    )
+    assert utils.get_zone_info("UTC").key == "UTC"  # type:ignore[union-attr]
+
+
+@pytest.mark.parametrize("zone_key", ["Invalid", "Space/Earth", ""])
+def test_get_invalid_zone_info(zone_key: str) -> None:
+    assert utils.get_zone_info(zone_key) is None
+
+
+def test_naive_datetime() -> None:
+    assert utils.is_naive(datetime.now())
+    assert not utils.is_naive(datetime.now().astimezone(ZoneInfo("UTC")))
+    assert not utils.is_naive(datetime.now().astimezone(ZoneInfo("Europe/London")))
+    assert not utils.is_naive(
+        datetime.now().astimezone(ZoneInfo("America/Los_Angeles"))
+    )


### PR DESCRIPTION
Defining times in UTC makes defining times more complicated when trying to account for daylight savings. Instead, allow defining a base timezone for all apps, and per-app timezones. Defining a timezone should help more sensibly account for daylight savings.